### PR TITLE
Add Custom memory manager support to JIT

### DIFF
--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/ExecutionEngine.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/ExecutionEngine.cs
@@ -10,9 +10,9 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
     // Misplaced using directive; It isn't misplaced - tooling is too brain dead to know the difference between an alias and a using directive
 #pragma warning disable IDE0065, SA1200, SA1135
     using unsafe LLVMMemoryManagerAllocateCodeSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, byte* /*retVal*/>;
-    using unsafe LLVMMemoryManagerAllocateDataSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, bool /*IsReadOnly*/, byte* /*retVal*/>;
+    using unsafe LLVMMemoryManagerAllocateDataSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, /*LLVMBool*/ Int32 /*IsReadOnly*/, byte* /*retVal*/>;
     using unsafe LLVMMemoryManagerDestroyCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, void /*retVal*/ >;
-    using unsafe LLVMMemoryManagerFinalizeMemoryCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, byte** /*ErrMsg*/, bool /*retVal*/>;
+    using unsafe LLVMMemoryManagerFinalizeMemoryCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, byte** /*ErrMsg*/, /*LLVMBool*/ Int32 /*retVal*/>;
 #pragma warning restore IDE0065, SA1200, SA1135
 
     [StructLayout( LayoutKind.Sequential )]

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/OrcEE.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/OrcEE.cs
@@ -6,10 +6,10 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
     // Misplaced using directive; It isn't misplaced - tooling is too brain dead to know the difference between an alias and a using directive
 #pragma warning disable IDE0065, SA1200, SA1135
     using unsafe LLVMMemoryManagerAllocateCodeSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, byte* /*retVal*/>;
-    using unsafe LLVMMemoryManagerAllocateDataSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, bool /*IsReadOnly*/, byte* /*retVal*/>;
+    using unsafe LLVMMemoryManagerAllocateDataSectionCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, nuint /*Size*/, uint /*Alignment*/, uint /*SectionID*/, byte* /*SectionName*/, /*LLVMBool*/ Int32 /*IsReadOnly*/, byte* /*retVal*/>;
     using unsafe LLVMMemoryManagerCreateContextCallback = delegate* unmanaged[Cdecl]< void* /*CtxCtx*/, void* /*retVal*/>;
     using unsafe LLVMMemoryManagerDestroyCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, void /*retVal*/ >;
-    using unsafe LLVMMemoryManagerFinalizeMemoryCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, byte** /*ErrMsg*/, bool /*retVal*/>;
+    using unsafe LLVMMemoryManagerFinalizeMemoryCallback = delegate* unmanaged[Cdecl]< void* /*Opaque*/, byte** /*ErrMsg*/, /*LLVMBool*/ Int32 /*retVal*/>;
     using unsafe LLVMMemoryManagerNotifyTerminatingCallback = delegate* unmanaged[Cdecl]< void* /*CtxCtx*/, void /*retVal*/>;
 #pragma warning restore IDE0065, SA1200, SA1135
 

--- a/src/Ubiquity.NET.InteropHelpers/SafeGCHandle.cs
+++ b/src/Ubiquity.NET.InteropHelpers/SafeGCHandle.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Ubiquity.NET.InteropHelpers
@@ -25,10 +26,10 @@ namespace Ubiquity.NET.InteropHelpers
     /// should otherwise account for the ref count increase to hold the instance alive. That
     /// is, by holding a <see cref="GCHandle"/> to self, with an AddRef'd handle the instance
     /// would live until the app is terminated! Thus applications using this MUST understand
-    /// the native code use and account for the disposable of any instances with this as a
+    /// the native code use and account for the disposale of any instances with this as a
     /// member. Typically a callback provided to the native code is used to indicate release
-    /// of the resource. That callback will call dispose to decrement the refcount on the
-    /// handle. If the ref count lands at 0, then the object it refers to is subject to
+    /// of the resource. That callback will call dispose to decrement the refcount on this
+    /// GC handle. If the ref count lands at 0, then the object it refers to is subject to
     /// normal GC.</para>
     /// </remarks>
     public sealed class SafeGCHandle
@@ -59,6 +60,7 @@ namespace Ubiquity.NET.InteropHelpers
         {
             bool ignoredButRequired = false;
             DangerousAddRef( ref ignoredButRequired );
+            Debug.Assert(ignoredButRequired, "DangerousAddRef on the GC handle did NOT succeed!");
             return handle;
         }
 

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/ExecutionSession.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/ExecutionSession.cs
@@ -264,6 +264,7 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
 
         internal LLVMOrcExecutionSessionRef Handle { get; init; }
 
+#if FUTURE_DEVELOPMENT_AREA
         /// <summary>Native code callback for error reporting</summary>
         /// <param name="context">The context for the callback is a <see cref="GCHandle"/> with a target of <see cref="ErrorReporter"/></param>
         /// <param name="abiErrorRef">ABI handle for an error ref</param>
@@ -292,5 +293,6 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
                 Debug.Assert( false, "Exception in native callback!" );
             }
         }
+#endif
     }
 }

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/IJitMemoryAllocator.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/IJitMemoryAllocator.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+#pragma warning disable SA1649 // Filename must match type name
+#pragma warning disable SA1600 // Elements must be documented
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'Type_or_Member'
+
+namespace Ubiquity.NET.Llvm.OrcJITv2
+{
+    public interface IJitMemoryAllocator
+        : IDisposable
+    {
+        /// <summary>Allocate a block of contiguous memory for use as code execution by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator
+        /// <note type="important">
+        /// The Execute only page setting and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write code into the memory area even if it is ultimately Execute-Only.
+        /// </note>
+        /// </remarks>
+        nuint AllocateCodeSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName );
+
+        /// <summary>Allocate a block of contiguous memory for use as data by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <param name="isReadOnly">Memory section is Read-Only</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator.
+        /// <note type="important">
+        /// The <paramref name="isReadOnly"/> and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write initial data into the memory even if it is ultimately Read-Only.
+        /// </note>
+        /// </remarks>
+        nuint AllocateDataSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName, bool isReadOnly);
+
+        /// <summary>Finalizes a previous allocation by applying page settings for the allocation</summary>
+        /// <param name="errMsg">Error message in the event of a failure</param>
+        /// <returns><see langword="true"/> if successfull (<paramref name="errMsg"/> is <see langword="null"/>); <see langword="false"/> if not (<paramref name="errMsg"/> has the reason)</returns>
+        bool FinalizeMemory([NotNullWhen(false)] out LazyEncodedString? errMsg);
+    }
+}

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/MemoryAllocatorNativeCallbacks.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/MemoryAllocatorNativeCallbacks.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+namespace Ubiquity.NET.Llvm.OrcJITv2
+{
+    // Native only callbacks that use a SafeGCHandle as the "context" to allow
+    // the native API to re-direct to the proper managed implementation instance.
+    // (That is, this is a revers P/Invoke that handles marshalling of parameters
+    // and return type for native callers into managed code)
+    internal static class MemoryAllocatorNativeCallbacks
+    {
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe void *CreateContext(void* outerContext)
+        {
+            return outerContext;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe void DestroyContext(void *ctx)
+        {
+            /* Intentional NOP */
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe byte* AllocateCodeSection(void* ctx, nuint size, UInt32 alignment, UInt32 sectionId, byte* sectionName)
+        {
+            return MarshalGCHandle.TryGet<IJitMemoryAllocator>( ctx, out IJitMemoryAllocator? self )
+                ? (byte*)self.AllocateCodeSection(size, alignment, sectionId, LazyEncodedString.FromUnmanaged(sectionName))
+                : (byte*)null;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe byte* AllocateDataSection(
+            void* ctx,
+            nuint size,
+            UInt32 alignment,
+            UInt32 sectionId,
+            byte* sectionName,
+            /*LLVMBool*/Int32 isReadOnly
+            )
+        {
+            return MarshalGCHandle.TryGet<IJitMemoryAllocator>( ctx, out IJitMemoryAllocator? self )
+                ? (byte*)self.AllocateDataSection(size, alignment, sectionId, LazyEncodedString.FromUnmanaged(sectionName), isReadOnly != 0)
+                : (byte*)null;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe /*LLVMStatus*/ Int32 FinalizeMemory(void* ctx, byte** errMsg)
+        {
+            *errMsg = null;
+            if(MarshalGCHandle.TryGet<IJitMemoryAllocator>( ctx, out IJitMemoryAllocator? self ))
+            {
+                if(!self.FinalizeMemory(out LazyEncodedString? managedErrMsg))
+                {
+                    AllocateAndSetNativeMessage( errMsg, managedErrMsg.ToReadOnlySpan(includeTerminator: true));
+                }
+            }
+
+            AllocateAndSetNativeMessage( errMsg, "Invalid context provided to FinalizeMemory callback!"u8);
+            return 0;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe void DestroyMemory(void* ctx)
+        {
+            if(MarshalGCHandle.TryGet<IJitMemoryAllocator>( ctx, out IJitMemoryAllocator? self ))
+            {
+#pragma warning disable IDISP007 // Don't dispose injected
+                // NOT injected; ref counted, native code is releasing ref count via this call
+                self.Dispose();
+#pragma warning restore IDISP007 // Don't dispose injected
+            }
+        }
+
+        // WARNING: Native caller ***WILL*** call `free(*errMsg)` if `*errMsg != nullptr`!!
+        //          Therefore, any error message returned should be allocated with NativeMemory.Alloc()
+        //          to allow free() on the pointer.
+        private static unsafe void AllocateAndSetNativeMessage( byte** errMsg, ReadOnlySpan<byte> managedErrMsg )
+        {
+            nuint len = (nuint)managedErrMsg.Length;
+            void* p = NativeMemory.Alloc(len);
+            var nativeMsgSpan = new Span<byte>(p, (int)len);
+            managedErrMsg.CopyTo( nativeMsgSpan );
+            *errMsg = (byte*)p;
+        }
+    }
+}

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/ObjectLayer.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/ObjectLayer.cs
@@ -6,8 +6,8 @@ using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Orc;
 namespace Ubiquity.NET.Llvm.OrcJITv2
 {
     /// <summary>ORC JIT v2 Object linking layer</summary>
-    public sealed class ObjectLayer
-        : IDisposable
+    public class ObjectLayer
+        : DisposableObject
     {
         /// <summary>Adds an object file to the specified library</summary>
         /// <param name="jitDyLib">Library to add the object file to</param>
@@ -60,8 +60,9 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
 
         /// <inheritdoc/>
         [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP007:Don't dispose injected", Justification = "Ownership transferred in constructor")]
-        public void Dispose( )
+        protected override void Dispose( bool disposing )
         {
+            base.Dispose(disposing);
             if(!Handle.IsNull)
             {
                 Handle.Dispose();
@@ -74,6 +75,25 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
             Handle = h;
         }
 
-        internal LLVMOrcObjectLayerRef Handle { get; private set; }
+        internal ObjectLayer()
+        {
+        }
+
+        internal LLVMOrcObjectLayerRef Handle
+        {
+            get;
+
+            // Only accessible from derived types, since the modifier of this property is `internal` that
+            // means `internal` AND `protected`
+            private protected set
+            {
+                if(!field.IsNull)
+                {
+                    throw new InvalidOperationException("INTERNAL: Setting handle multiple times is not allowed!");
+                }
+
+                field = value;
+            }
+        }
     }
 }

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/RTDyldObjMemoryAllocatorBase.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/RTDyldObjMemoryAllocatorBase.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.OrcEE;
+
+namespace Ubiquity.NET.Llvm.OrcJITv2
+{
+    /// <summary>Base class for an allocator for use as an Object layer in OrcJITv2</summary>
+    public abstract class RTDyldObjMemoryAllocatorBase
+        : ObjectLayer
+        , IJitMemoryAllocator
+    {
+        /// <summary>Initializes a new instance of the <see cref="RTDyldObjMemoryAllocatorBase"/> class.</summary>
+        /// <param name="session">Session for this object layer</param>
+        protected RTDyldObjMemoryAllocatorBase(ExecutionSession session)
+            : base()
+        {
+            AllocatedSelf = new(this);
+            unsafe
+            {
+                Handle = LLVMOrcCreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks(
+                            session.Handle,
+                            (void*)AddRefAndGetNativeContext(),
+                            &MemoryAllocatorNativeCallbacks.CreateContext,
+                            &MemoryAllocatorNativeCallbacks.DestroyMemory, // Notify Terminating
+                            &MemoryAllocatorNativeCallbacks.AllocateCodeSection,
+                            &MemoryAllocatorNativeCallbacks.AllocateDataSection,
+                            &MemoryAllocatorNativeCallbacks.FinalizeMemory,
+                            &MemoryAllocatorNativeCallbacks.DestroyContext // NOP
+                         );
+            }
+        }
+
+        /// <summary>Allocate a block of contiguous memory for use as code execution by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator
+        /// <note type="important">
+        /// The Execute only page setting and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write code into the memory area even if it is ultimately Execute-Only.
+        /// </note>
+        /// </remarks>
+        public abstract nuint AllocateCodeSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName );
+
+        /// <summary>Allocate a block of contiguous memory for use as data by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <param name="isReadOnly">Memory section is Read-Only</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator.
+        /// <note type="important">
+        /// The <paramref name="isReadOnly"/> and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write initial data into the memory even if it is ultimately Read-Only.
+        /// </note>
+        /// </remarks>
+        public abstract nuint AllocateDataSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName, bool isReadOnly);
+
+        /// <summary>Finalizes a previous allocation by applying page settings for the allocation</summary>
+        /// <param name="errMsg">Error message in the event of a failure</param>
+        /// <returns><see langword="true"/> if successfull (<paramref name="errMsg"/> is <see langword="null"/>); <see langword="false"/> if not (<paramref name="errMsg"/> has the reason)</returns>
+        public abstract bool FinalizeMemory([NotNullWhen(false)] out LazyEncodedString? errMsg);
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            if(disposing && !AllocatedSelf.IsInvalid && !AllocatedSelf.IsClosed)
+            {
+                // Decrements the ref count on the handle
+                // might not actually destroy anything
+                AllocatedSelf.Dispose();
+            }
+
+            base.Dispose( disposing );
+        }
+
+        internal unsafe nint AddRefAndGetNativeContext( )
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+            return AllocatedSelf.AddRefAndGetNativeContext();
+        }
+
+        // This is the key to ref counted behavior to hold this instance (and anything it references)
+        // alive for the GC. The "ownership" of the refcount is handed to native code while the
+        // calling code is free to no longer reference this instance as it holds an allocated
+        // GCHandle for itself and THAT is kept alive by a ref count that is "owned" by native code.
+        private SafeGCHandle AllocatedSelf { get; }
+    }
+}

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/SimpleJitMemoryAllocatorBase.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/SimpleJitMemoryAllocatorBase.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+#pragma warning disable SA1649 // Filename must match type name
+#pragma warning disable SA1600 // Elements must be documented
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'Type_or_Member'
+
+using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ExecutionEngine;
+
+namespace Ubiquity.NET.Llvm.OrcJITv2
+{
+    public abstract class SimpleJitMemoryAllocatorBase
+        : DisposableObject
+        , IJitMemoryAllocator
+    {
+        protected SimpleJitMemoryAllocatorBase()
+        {
+            AllocatedSelf = new(this);
+            unsafe
+            {
+                Handle = LLVMCreateSimpleMCJITMemoryManager(
+                    (void*)AddRefAndGetNativeContext(),
+                    &MemoryAllocatorNativeCallbacks.AllocateCodeSection,
+                    &MemoryAllocatorNativeCallbacks.AllocateDataSection,
+                    &MemoryAllocatorNativeCallbacks.FinalizeMemory,
+                    &MemoryAllocatorNativeCallbacks.DestroyMemory
+                    );
+            }
+        }
+
+        /// <summary>Allocate a block of contiguous memory for use as code execution by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator
+        /// <note type="important">
+        /// The Execute only page setting and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write code into the memory area even if it is ultimately Execute-Only.
+        /// </note>
+        /// </remarks>
+        public abstract nuint AllocateCodeSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName );
+
+        /// <summary>Allocate a block of contiguous memory for use as data by the native code JIT engine</summary>
+        /// <param name="size">Size of the block</param>
+        /// <param name="alignment">alignment requirements of the block</param>
+        /// <param name="sectionId">ID for the section</param>
+        /// <param name="sectionName">Name of the section</param>
+        /// <param name="isReadOnly">Memory section is Read-Only</param>
+        /// <returns>Address of the first byte of the allocated memory</returns>
+        /// <remarks>
+        /// If the memory is allocated from the managed heap then the returned address <em><i>MUST</i></em>
+        /// remain pinned until <see cref="IDisposable.Dispose"/> is called on this allocator.
+        /// <note type="important">
+        /// The <paramref name="isReadOnly"/> and any other page properties is not applied to the returned
+        /// address (or entire memory of the allocated section) until <see cref="FinalizeMemory"/> is called.
+        /// This allows the JIT to write initial data into the memory even if it is ultimately Read-Only.
+        /// </note>
+        /// </remarks>
+        public abstract nuint AllocateDataSection(nuint size, UInt32 alignment, UInt32 sectionId, LazyEncodedString sectionName, bool isReadOnly);
+
+        /// <summary>Finalizes a previous allocation by applying page settings for the allocation</summary>
+        /// <param name="errMsg">Error message in the event of a failure</param>
+        /// <returns><see langword="true"/> if successfull (<paramref name="errMsg"/> is <see langword="null"/>); <see langword="false"/> if not (<paramref name="errMsg"/> has the reason)</returns>
+        public abstract bool FinalizeMemory([NotNullWhen(false)] out LazyEncodedString? errMsg);
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            if(disposing && !AllocatedSelf.IsInvalid && !AllocatedSelf.IsClosed)
+            {
+                // Decrements the ref count on the handle
+                // might not actually destroy anything
+                AllocatedSelf.Dispose();
+            }
+
+            Handle = default;
+            base.Dispose( disposing );
+        }
+
+        internal unsafe nint AddRefAndGetNativeContext( )
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+            return AllocatedSelf.AddRefAndGetNativeContext();
+        }
+
+        // This is the key to ref counted behavior to hold this instance (and anything it references)
+        // alive for the GC. The "ownership" of the refcount is handed to native code while the
+        // calling code is free to no longer reference this instance as it holds an allocated
+        // GCHandle for itself and THAT is kept alive by a ref count that is "owned" by native code.
+        private SafeGCHandle AllocatedSelf { get; }
+
+        private LLVMMCJITMemoryManagerRef Handle;
+    }
+}

--- a/src/Ubiquity.NET.TextUX/PackageReadMe.md
+++ b/src/Ubiquity.NET.TextUX/PackageReadMe.md
@@ -6,7 +6,9 @@ Text based UI/UX. This is generally only relevant for console based apps.
 `IDiagnosticReporter` interface is at the core of the UX. It is similar in many ways to many
 of the logging interfaces available. The primary distinction is with the ***intention*** of
 use. `IDiagnosticReporter` specifically assumes the use for UI/UX rather than a
-debugging/diagnostic log.
+debugging/diagnostic log. These have VERY distinct use cases and purposes and generally show
+very different information. (Not to mention the overlly complex requirements of
+the anti-pattern DI container assumed in `Microsoft.Extensions.Logging`)
 
 ### Messages
 All messages for the UX use a simple immutable structure to store the details of a message
@@ -17,7 +19,8 @@ There are a few pre-built implementation of the `IDiagnosticReporter` interface.
 * `TextWriterReporter`
     * Base class for writing UX to a `TextWriter`
 * `ConsoleReporter`
-    * Reporter that reports errors to `Console.Error` and all other errors to `Console.Out`
+    * Reporter that reports errors to `Console.Error` and all other nessages to
+      `Console.Out`
 * `ColoredConsoleReporter`
     * `ConsoleReporter` that colorizes output using ANSI color codes
         * Colors are customizable, but contains a common default

--- a/src/Ubiquity.NET.TextUX/SourceRange.cs
+++ b/src/Ubiquity.NET.TextUX/SourceRange.cs
@@ -11,6 +11,11 @@ namespace Ubiquity.NET.TextUX
     // Column position of the location [0..n-1]
 
     /// <summary>Abstraction to hold a source location range as a pair of <see cref="SourcePosition"/> values</summary>
+    /// <remarks>
+    /// It is possible that some sources do not provide dual points to make a proper range. This supports such
+    /// "ranges" as a single point that is not sliceable. This allows callers to deal with sources that only
+    /// contain the start point (Looking at you <see cref="System.Xml.IXmlLineInfo"/>!).
+    /// </remarks>
     public readonly record struct SourceRange
         : IFormattable
     {


### PR DESCRIPTION
Add Custom memory manager support to JIT
* This adds the types but doesn't yet use/test them
    - Future PR will add them once testing is done
* Fixed declaration of native callback function pointers
    - Can't use bool for LLVMBool as that requires marshaling
* Added debug assert for `SafeGCHandle.AddRefAndGetNativeContext` to complain in a debug build if the underlying AddRef fails for some reason.
    - Docs on behavior of that API are a bit dodgy and it isn't clear how it could ever provide an out parameter of non-success
* Added additional preprocessor checks to disable unused code
* Added `IJitMemoryAllocator` to support either MCJIT simple allocator or an OrcJitV2 Object layer.
* Readme and doc comment corrections/clarifications